### PR TITLE
Use tox {posargs} to make test running more flexible

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals =
 deps =
     -r{toxinidir}/requirements/test-requirements-py27-py3.txt
 commands =
-    coverage run -m nose
+    coverage run -m nose {posargs}
     coverage xml
     git fetch origin master:refs/remotes/origin/master
     diff-cover coverage.xml
@@ -20,4 +20,3 @@ deps =
     -r{toxinidir}/requirements/test-requirements-py26.txt
     argparse
     unittest2
-


### PR DESCRIPTION
By adding {posargs} to the nose line, you can now add nose arguments to the tox command line, and they will be passed along.  So for example, `tox -e py27 -- -v` will run all the tests, verbosely, on 2.7