### PR TITLE
filtering '--source' source path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Matt Bachmann <bachmann.matt@gmail.com>
 David Baumgold <david@davidbaumgold.com>
 Ricardo Newbery <ric@digitalmarbles.com>
 Daniel Cardin <danielcardin@outlook.com>
+Jeff Fairley <jfairley@gmail.com>

--- a/diff_cover/tests/fixtures/dotnet_coverage.xml
+++ b/diff_cover/tests/fixtures/dotnet_coverage.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
 <coverage line-rate="0.75" branch-rate="1" lines-covered="9" lines-valid="12" branches-covered="0" branches-valid="0" complexity="0" version="0" timestamp="1410969572">
   <sources>
+    <source>--source</source>
     <source>/code/samplediff/SampleApp</source>
   </sources>
   <packages>

--- a/diff_cover/violations_reporter.py
+++ b/diff_cover/violations_reporter.py
@@ -105,8 +105,8 @@ class XmlCoverageReporter(BaseViolationReporter):
 
         # cobertura sometimes provides the sources for the measurements
         # within it. If we have that we outta use it
-        sources = xml_document.findall('sources')
-        sources = [source.find('source').text for source in sources]
+        sources = xml_document.findall('sources/source')
+        sources = [source.text for source in sources]
         classes = [class_tree
                    for class_tree in xml_document.findall(".//class")
                    or []]


### PR DESCRIPTION
@Bachmann1234 

Let me apologize in advance for the lack of tests in this PR. I don't know python, so I'm definitely looking for an assist on this.

I'm generating cobertura xml for Java using the [Maven Cobertura plugin](http://mojo.codehaus.org/cobertura-maven-plugin/) (version 2.7). My resulting XML always contains a `--source` source path. I have no special configs, so I can only assume this is some oddity of the maven plugin.

```xml
<sources>
        <source>/Users/jfairley/Development/workspace-git/reach-engine/reach-engine-core/target/generated-sources/xmlbeans</source>
        <source>/Users/jfairley/Development/workspace-git/reach-engine/reach-engine-core/target/generated-sources/metamodel</source>
        <source>--source</source>
        <source>/Users/jfairley/Development/workspace-git/reach-engine/reach-engine-core/src/main/java</source>
        <source>/Users/jfairley/Development/workspace-git/reach-engine/reach-engine-core/target/generated-sources/antlr4</source>
</sources>
```

The line doing [`os.path.join`](https://github.com/Bachmann1234/diff-cover/blob/591d811ed6edbcdc185199fc88cdf0b85429571b/diff_cover/violations_reporter.py#L117) always fails when it gets to `--source`, resulting in it missing all source paths that follow `--source`. This causes me to commonly see `No lines with coverage information in this diff.` even when there should be. In Jenkins, I have to use grep to strip this line before running `diff-cover`.

Again, sorry for the lack of tests. Feel free to push extra commits to this PR or just close and fix it in your own way.

Also, thanks for such a neat tool. I've hooked this into our company's github pull request validation so that every check-in can be vetted for proper test coverage. :+1: 