### PR TITLE
Display valid HTML long description on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 diff-cover |build-status| |coverage-status| |requirements-status| |docs-status|
-=================================================================
+===============================================================================
 
 Automatically find diff lines that need test coverage.
 Also finds diff lines that have violations (according to tools such as pep8,


### PR DESCRIPTION
The long description on PyPI is busted (i.e. showing raw reStructuredText rather than HTML). The problem is that PyPI expects perfect reStructuredText. I ran the README through rst2html.py to confirm that the issue is `Title underline too short.` This quick fix addresses that.