### PR TITLE
Add jshint as a violations reporter.

### DIFF
--- a/diff_cover/tool.py
+++ b/diff_cover/tool.py
@@ -13,7 +13,7 @@ from diff_cover.git_path import GitPathTool
 from diff_cover.violations_reporter import (
     XmlCoverageReporter, Pep8QualityReporter,
     PyflakesQualityReporter, PylintQualityReporter,
-    Flake8QualityReporter
+    Flake8QualityReporter, JsHintQualityReporter
 )
 from diff_cover.report_generator import (
     HtmlReportGenerator, StringReportGenerator,
@@ -35,6 +35,7 @@ QUALITY_REPORTERS = {
     'pyflakes': PyflakesQualityReporter,
     'pylint': PylintQualityReporter,
     'flake8': Flake8QualityReporter,
+    'jshint': JsHintQualityReporter,
 }
 
 

--- a/diff_cover/violations_reporter.py
+++ b/diff_cover/violations_reporter.py
@@ -505,6 +505,15 @@ class PylintQualityReporter(BaseQualityReporter):
         return violations_dict
 
 
+class JsHintQualityReporter(BaseQualityReporter):
+    """
+    Report JSHint violations.
+    """
+    COMMAND = 'jshint'
+    EXTENSIONS = ['js']
+    VIOLATION_REGEX = re.compile(r'^([^:]+): line (\d+), col (\d+), (.*)$')
+
+
 class QualityReporterError(Exception):
     """
     A quality reporter command produced an error.


### PR DESCRIPTION
Hey @Bachmann1234 - 

This PR is not ready; I wanted to ask for any suggestions you might have before continuing to work on it. 

We're using jshint as part of our quality process, and--in our case--it is an npm install; not a pip install. However, the tool is available via CLI.

So, as it stands, diff-quality won't pick up the new reporter because of an import error, that's essentially coming from [here](https://github.com/Bachmann1234/diff-cover/blob/master/diff_cover/violations_reporter.py#L261). 

I could solve this in a few different ways and wanted to see what you thought:
* A bit that is overridden on the implementation class which will essentially say "test this via CLI, not via __import__"
* A try/catch mechanism in the base class that essentially says "if it's not available via import, use COMMAND with "-h" and see if it exits 0.
* Some combination of the above, wherein the implementing class has some kind of "HOW-TO-TEST-IF-THIS-IS-INSTALLED-COMMAND", and that is executed if it exists, rather than __import__.

Hopefully this is making sense! I just wanted to ping you on this before I spent more time on it. Thanks for any help!