### PR TITLE
Fix executing the script in windows

### DIFF
--- a/diff_cover/tool.py
+++ b/diff_cover/tool.py
@@ -231,7 +231,7 @@ def main(argv=None, directory=None):
 
     GitPathTool.set_cwd(directory)
 
-    if progname.endswith('diff-cover'):
+    if 'diff-cover' in progname:
         arg_dict = parse_coverage_args(argv[1:])
         fail_under = arg_dict.get('fail_under')
         percent_covered = generate_coverage_report(
@@ -247,7 +247,7 @@ def main(argv=None, directory=None):
             LOGGER.error("Failure. Coverage is below {0}%.".format(fail_under))
             return 1
 
-    elif progname.endswith('diff-quality'):
+    elif 'diff-quality' in progname:
         arg_dict = parse_quality_args(argv[1:])
         fail_under = arg_dict.get('fail_under')
         tool = arg_dict['violations']


### PR DESCRIPTION
Windows makes a different script name then unix environments. The script should still run in these cases. I am worried about windows pathing but ill tackle that if it comes