### PR TITLE
Normalize paths to unix as they are read in

### DIFF
--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -112,7 +112,6 @@ class GitDiffReporter(BaseDiffReporter):
 
         return included
 
-
     def _git_diff(self):
         """
         Run `git diff` and returns a dict in which the keys
@@ -137,7 +136,6 @@ class GitDiffReporter(BaseDiffReporter):
                 diff_dict = self._parse_diff_str(diff_str)
 
                 for src_path in diff_dict.keys():
-
                     added_lines, deleted_lines = diff_dict[src_path]
 
                     # Remove any lines from the dict that have been deleted

--- a/diff_cover/tests/fixtures/git_diff_lua.txt
+++ b/diff_cover/tests/fixtures/git_diff_lua.txt
@@ -1,0 +1,13 @@
+diff --git a/scripts/maths.lua b/scripts/maths.lua
+index d31c441..bcd11a9 100644
+--- a/scripts/maths.lua
++++ b/scripts/maths.lua
+@@ -8,4 +8,8 @@ function maths.subber(a, b)
+    return a - b
+ end
+
++function maths.mult(a,b)
++   return a * b
++end
++
+ return maths

--- a/diff_cover/tests/fixtures/lua_console_report.txt
+++ b/diff_cover/tests/fixtures/lua_console_report.txt
@@ -1,0 +1,10 @@
+-------------
+Diff Coverage
+Diff: origin/master...HEAD, staged, and unstaged changes
+-------------
+scripts/maths.lua (50.0%): Missing lines 12
+-------------
+Total:   2 lines
+Missing: 1 line
+Coverage: 50%
+-------------

--- a/diff_cover/tests/fixtures/luacoverage.xml
+++ b/diff_cover/tests/fixtures/luacoverage.xml
@@ -1,0 +1,34 @@
+<coverage line-rate="0.90909090909091" version="1.9" branch-rate="0" timestamp="1442271411000">
+    <packages>
+        <package line-rate="0.875" name="" branch-rate="0" complexity="0">
+            <classes>
+                <class line-rate="0.875" name=".\scripts\maths.lua" branch-rate="0" complexity="0" filename=".\scripts\maths.lua">
+                    <methods/>
+                    <lines>
+                        <line number="1" branch="false" hits="1"/>
+                        <line number="3" branch="false" hits="1"/>
+                        <line number="4" branch="false" hits="1"/>
+                        <line number="7" branch="false" hits="1"/>
+                        <line number="8" branch="false" hits="1"/>
+                        <line number="11" branch="false" hits="1"/>
+                        <line number="12" branch="false" hits="0"/>
+                        <line number="15" branch="false" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+        <package line-rate="1" name="tests" branch-rate="0" complexity="0">
+            <classes>
+                <class line-rate="1" name="test.lua" branch-rate="0" complexity="0" filename="tests/test.lua">
+                    <methods/>
+                    <lines>
+                        <line number="1" branch="false" hits="1"/>
+                        <line number="3" branch="false" hits="1"/>
+                        <line number="4" branch="false" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+    <sources/>
+</coverage>

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -172,6 +172,17 @@ class DiffCoverIntegrationTest(ToolsIntegrationBase):
             ['diff-cover', 'coverage.xml']
         )
 
+    def test_lua_coverage(self):
+        """
+        coverage report shows that diff-cover needs to normalize
+        paths read in
+        """
+        self._check_console_report(
+            'git_diff_lua.txt',
+            'lua_console_report.txt',
+            ['diff-cover', 'luacoverage.xml']
+        )
+
     def test_fail_under_console(self):
         self._check_console_report(
             'git_diff_add.txt',


### PR DESCRIPTION
This issue came up as a follow up to https://github.com/Bachmann1234/diff-cover/issues/17

Basically the coverage report had inconsistent path styles. This PR attempts to normalize them as they are read in.

I tried `os.path.normpath` but that did not make any difference in my test environment... I think this may mean more about my test environment then anything else. Luckily going from windows to unix is fairly easy.