### PR TITLE
Fix git-diff with `mnemonicprefix` option

### DIFF
--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -33,10 +33,8 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return self._execute([
-            'git', 'diff',
-            "{branch}...HEAD".format(branch=compare_branch),
-            '--no-ext-diff'
+        return self._run_diff([
+            '{branch}...HEAD'.format(branch=compare_branch),
         ])
 
     def diff_unstaged(self):
@@ -47,7 +45,7 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return self._execute(['git', 'diff', '--no-ext-diff'])
+        return self._run_diff([])
 
     def diff_staged(self):
         """
@@ -57,16 +55,17 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return self._execute(['git', 'diff', '--cached', '--no-ext-diff'])
+        return self._run_diff(['--cached'])
 
-    def _execute(self, command):
+    def _run_diff(self, args):
         """
-        Execute `command` (list of command components)
-        and returns the output.
+        Execute `git diff` with `args` and returns the output.
 
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
+        command = ['git', '-c', 'diff.mnemonicprefix=no', 'diff',
+                   '--no-ext-diff'] + args
         stdout_pipe = self._subprocess.PIPE
         process = self._subprocess.Popen(
             command, stdout=stdout_pipe,


### PR DESCRIPTION
With `diff.mnemonicprefix`, the prefixes would not be just `a` and `b`,
and therefore the regexp would not match.

This also refactors `_execute` into `_run_diff`.

This could be improved further by making `git` not use any user
configuration, e.g. by setting `$HOME` to `/dev/null`.