### PR TITLE
Add support for prospector.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Daniel Cardin <danielcardin@outlook.com>
 Jeff Fairley <jfairley@gmail.com>
 Radosław Ganczarek <radoslaw@ganczarek.in>
 Daniel Milde <daniel@milde.cz>
+Chris Faulkner <thefaulkner@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ diff-cover |build-status| |coverage-status| |requirements-status| |docs-status|
 
 Automatically find diff lines that need test coverage.
 Also finds diff lines that have violations (according to tools such as pep8,
-pyflakes, flake8, or pylint).
+pyflakes, flake8, prospector, or pylint).
 This is used as a code quality metric during code reviews.
 
 Overview
@@ -120,8 +120,8 @@ You can use diff-cover to see quality reports on the diff as well by running
     diff-quality --violations=<tool>
 
 Where ``tool`` is the quality checker to use. Currently ``pep8``, ``pyflakes``,
-``flake8``, and ``pylint`` are supported, but more checkers can (and should!)
-be integrated.
+``flake8``, ``prospector``, and ``pylint`` are supported, but more checkers can
+(and should!) be integrated.
 
 Like ``diff-cover``, HTML reports can be generated with
 
@@ -130,9 +130,9 @@ Like ``diff-cover``, HTML reports can be generated with
     diff-quality --violations=<tool> --html-report report.html
 
 If you have already generated a report using ``pep8``, ``pyflakes``, ``flake8``,
-or ``pylint`` you can pass the report to ``diff-quality``.  This is more
+``prospector``, or ``pylint`` you can pass the report to ``diff-quality``.  This is more
 efficient than letting ``diff-quality`` re-run ``pep8``, ``pyflakes``,
-``flake8``, or ``pylint``.
+``flake8``, ``prospector``, or ``pylint``.
 
 .. code:: bash
 
@@ -154,7 +154,7 @@ the ``pylint`` report for pylint versions less than 1.0 and the
 ``--msg-template`` option for versions >= 1.0.
 
 ``diff-quality`` will also accept multiple ``pep8``, ``pyflakes``, ``flake8``,
-or ``pylint`` reports:
+``prospector``, or ``pylint`` reports:
 
 .. code:: bash
 

--- a/diff_cover/tool.py
+++ b/diff_cover/tool.py
@@ -13,7 +13,8 @@ from diff_cover.git_path import GitPathTool
 from diff_cover.violations_reporter import (
     XmlCoverageReporter, Pep8QualityReporter,
     PyflakesQualityReporter, PylintQualityReporter,
-    Flake8QualityReporter, JsHintQualityReporter
+    Flake8QualityReporter, JsHintQualityReporter,
+    ProspectorQualityReporter
 )
 from diff_cover.report_generator import (
     HtmlReportGenerator, StringReportGenerator,
@@ -36,6 +37,7 @@ QUALITY_REPORTERS = {
     'pylint': PylintQualityReporter,
     'flake8': Flake8QualityReporter,
     'jshint': JsHintQualityReporter,
+    'prospector': ProspectorQualityReporter,
 }
 
 
@@ -104,7 +106,7 @@ def parse_quality_args(argv):
     valid options:
 
         {
-            'violations': pep8 | pyflakes | flake8 | pylint
+            'violations': pep8 | pyflakes | flake8 | pylint | prospector
             'html_report': None | HTML_REPORT
         }
 

--- a/diff_cover/violations_reporter.py
+++ b/diff_cover/violations_reporter.py
@@ -539,6 +539,14 @@ class PylintQualityReporter(BaseQualityReporter):
         return violations_dict
 
 
+class ProspectorQualityReporter(PylintQualityReporter):
+    """
+    Report Prospector violations.
+    """
+    COMMAND = 'prospector'
+    OPTIONS = ['-o', 'pylint']
+
+
 class JsHintQualityReporter(BaseQualityReporter):
     """
     Report JSHint violations.

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -5,4 +5,5 @@ coverage
 pep8
 flake8
 pyflakes
+prospector
 -r requirements.txt


### PR DESCRIPTION
See https://pypi.python.org/pypi/prospector

It's a fairly minimal change since I'm abusing the fact that prospector supports pylint as an output format.

I can add unit tests if you'd like this merged in.