### PR TITLE
Pass --no-color to git diff

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Ricardo Newbery <ric@digitalmarbles.com>
 Daniel Cardin <danielcardin@outlook.com>
 Jeff Fairley <jfairley@gmail.com>
 Radosław Ganczarek <radoslaw@ganczarek.in>
+Daniel Milde <daniel@milde.cz>

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -36,6 +36,7 @@ class GitDiffTool(object):
         return self._execute([
             'git', 'diff',
             "{branch}...HEAD".format(branch=compare_branch),
+            '--no-color',
             '--no-ext-diff'
         ])
 
@@ -47,7 +48,7 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return self._execute(['git', 'diff', '--no-ext-diff'])
+        return self._execute(['git', 'diff', '--no-color', '--no-ext-diff'])
 
     def diff_staged(self):
         """
@@ -57,7 +58,7 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return self._execute(['git', 'diff', '--cached', '--no-ext-diff'])
+        return self._execute(['git', 'diff', '--cached', '--no-color', '--no-ext-diff'])
 
     def _execute(self, command):
         """

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -26,7 +26,7 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', 'origin/master...HEAD', '--no-ext-diff']
+        expected = ['git', 'diff', 'origin/master...HEAD', '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -39,7 +39,7 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', '--no-ext-diff']
+        expected = ['git', 'diff', '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -52,7 +52,7 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', '--cached', '--no-ext-diff']
+        expected = ['git', 'diff', '--cached', '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -67,7 +67,7 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', 'release...HEAD', '--no-ext-diff']
+        expected = ['git', 'diff', 'release...HEAD', '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )


### PR DESCRIPTION
Diff-cover is not working when git configuration color.ui=always is set.