### PR TITLE
New option: --external-css-file

### DIFF
--- a/diff_cover/report_generator.py
+++ b/diff_cover/report_generator.py
@@ -362,4 +362,5 @@ class HtmlQualityReportGenerator(TemplateReportGenerator):
     Generate an HTML formatted diff quality report.
     """
     TEMPLATE_NAME = "html_quality_report.html"
+    CSS_TEMPLATE_NAME = "external_style.css"
     INCLUDE_SNIPPETS = True

--- a/diff_cover/templates/external_style.css
+++ b/diff_cover/templates/external_style.css
@@ -1,0 +1,7 @@
+.src-snippet { margin-top: 2em; }
+.src-name { font-weight: bold; }
+.snippets {
+    border-top: 1px solid #bdbdbd;
+    border-bottom: 1px solid #bdbdbd;
+}
+{{ snippet_style }}

--- a/diff_cover/templates/snippet_style.html
+++ b/diff_cover/templates/snippet_style.html
@@ -1,4 +1,7 @@
 {% if snippet_style %}
+{% if css_url %}
+        <link rel="stylesheet" href="{{ css_url }}">
+{% else %}
         <style>
             .src-snippet { margin-top: 2em; }
             .src-name { font-weight: bold; }
@@ -8,4 +11,5 @@
             }
             {{ snippet_style }}
         </style>
+{% endif %}
 {% endif %}

--- a/diff_cover/tests/fixtures/external_css_html_report.html
+++ b/diff_cover/tests/fixtures/external_css_html_report.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+    <head>
+        <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
+        <title>Diff Coverage</title>
+        <link rel="stylesheet" href="external_style.css">
+    </head>
+    <body>
+        <h1>Diff Coverage</h1>
+        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <ul>
+            <li><b>Total</b>: 1 line</li>
+            <li><b>Missing</b>: 0 lines</li>
+            <li><b>Coverage</b>: 100%</li>
+        </ul>
+        <table border="1">
+            <tr>
+                <th>Source File</th>
+                <th>Diff Coverage (%)</th>
+                <th>Missing Lines</th>
+            </tr>
+            <tr>
+                <td>test_src.txt</td>
+                <td>100%</td>
+                <td>&nbsp;</td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/diff_cover/tests/fixtures/external_style.css
+++ b/diff_cover/tests/fixtures/external_style.css
@@ -1,0 +1,68 @@
+.src-snippet { margin-top: 2em; }
+.src-name { font-weight: bold; }
+.snippets {
+    border-top: 1px solid #bdbdbd;
+    border-bottom: 1px solid #bdbdbd;
+}
+.hll { background-color: #ffcccc }
+.c { color: #408080; font-style: italic } /* Comment */
+.err { border: 1px solid #FF0000 } /* Error */
+.k { color: #008000; font-weight: bold } /* Keyword */
+.o { color: #666666 } /* Operator */
+.cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.cp { color: #BC7A00 } /* Comment.Preproc */
+.c1 { color: #408080; font-style: italic } /* Comment.Single */
+.cs { color: #408080; font-style: italic } /* Comment.Special */
+.gd { color: #A00000 } /* Generic.Deleted */
+.ge { font-style: italic } /* Generic.Emph */
+.gr { color: #FF0000 } /* Generic.Error */
+.gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.gi { color: #00A000 } /* Generic.Inserted */
+.go { color: #888888 } /* Generic.Output */
+.gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.gs { font-weight: bold } /* Generic.Strong */
+.gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.gt { color: #0044DD } /* Generic.Traceback */
+.kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.kp { color: #008000 } /* Keyword.Pseudo */
+.kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.kt { color: #B00040 } /* Keyword.Type */
+.m { color: #666666 } /* Literal.Number */
+.s { color: #BA2121 } /* Literal.String */
+.na { color: #7D9029 } /* Name.Attribute */
+.nb { color: #008000 } /* Name.Builtin */
+.nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.no { color: #880000 } /* Name.Constant */
+.nd { color: #AA22FF } /* Name.Decorator */
+.ni { color: #999999; font-weight: bold } /* Name.Entity */
+.ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.nf { color: #0000FF } /* Name.Function */
+.nl { color: #A0A000 } /* Name.Label */
+.nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.nt { color: #008000; font-weight: bold } /* Name.Tag */
+.nv { color: #19177C } /* Name.Variable */
+.ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.w { color: #bbbbbb } /* Text.Whitespace */
+.mb { color: #666666 } /* Literal.Number.Bin */
+.mf { color: #666666 } /* Literal.Number.Float */
+.mh { color: #666666 } /* Literal.Number.Hex */
+.mi { color: #666666 } /* Literal.Number.Integer */
+.mo { color: #666666 } /* Literal.Number.Oct */
+.sb { color: #BA2121 } /* Literal.String.Backtick */
+.sc { color: #BA2121 } /* Literal.String.Char */
+.sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.s2 { color: #BA2121 } /* Literal.String.Double */
+.se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.sh { color: #BA2121 } /* Literal.String.Heredoc */
+.si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.sx { color: #008000 } /* Literal.String.Other */
+.sr { color: #BB6688 } /* Literal.String.Regex */
+.s1 { color: #BA2121 } /* Literal.String.Single */
+.ss { color: #19177C } /* Literal.String.Symbol */
+.bp { color: #008000 } /* Name.Builtin.Pseudo */
+.vc { color: #19177C } /* Name.Variable.Class */
+.vg { color: #19177C } /* Name.Variable.Global */
+.vi { color: #19177C } /* Name.Variable.Instance */
+.il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/diff_cover/tests/fixtures/git_diff_external_css.txt
+++ b/diff_cover/tests/fixtures/git_diff_external_css.txt
@@ -1,0 +1,16 @@
+diff --git a/test_src.txt b/test_src.txt
+index 10ae772..74307ad 100644
+--- a/test_src.txt
++++ b/test_src.txt
+@@ -1,10 +1,8 @@
+-test 1
++changed
+ test 2
+ test 3
+ test 4
+ test 5
+ test 6
+ test 7
+-test 8
+-test 9
+ test 10

--- a/diff_cover/tests/fixtures/pep8_violations_report_external_css.html
+++ b/diff_cover/tests/fixtures/pep8_violations_report_external_css.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+    <head>
+        <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
+        <title>Diff Quality</title>
+        <link rel="stylesheet" href="external_style.css">
+    </head>
+    <body>
+        <h1>Diff Quality</h1>
+        <p>Quality Report: pep8</p>
+        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <table border="1">
+            <tr>
+                <th>Source File</th>
+                <th>Diff Quality (%)</th>
+                <th>Lines in violation</th>
+            </tr>
+            <tr>
+                <td>violations_test_file.py</td>
+                <td>66.7%</td>
+                <td>
+                    <ul>
+                        <li>2: E225 missing whitespace around operator</li>
+                        <li>6: E302 expected 2 blank lines, found 0</li>
+                        <li>11: E225 missing whitespace around operator</li>
+                    </ul>
+                </td>
+            </tr>
+        </table>
+        <ul>
+            <li><b>Total</b>: 9 lines</li>
+            <li><b>Violation</b>: 3 lines</li>
+            <li><b>% Quality</b>: 66%</li>
+        </ul>
+        <div class="src-snippet">
+            <div class="src-name">violations_test_file.py</div>
+            <div class="snippets">
+            <table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre> 1
+ 2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 8
+ 9
+10
+11
+12</pre></div></td><td class="code"><div class="snippet"><pre><a name="violations_test_file.py-1"></a><span class="k">def</span> <span class="nf">func_1</span><span class="p">(</span><span class="n">apple</span><span class="p">,</span> <span class="n">my_list</span><span class="p">):</span>
+<a name="violations_test_file.py-2"></a><span class="hll">    <span class="k">if</span> <span class="n">apple</span><span class="o">&lt;</span><span class="mi">10</span><span class="p">:</span>
+</span><a name="violations_test_file.py-3"></a>        <span class="c1"># Do something </span>
+<a name="violations_test_file.py-4"></a>        <span class="n">my_list</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">apple</span><span class="p">)</span>
+<a name="violations_test_file.py-5"></a>    <span class="k">return</span> <span class="n">my_list</span><span class="p">[</span><span class="mi">1</span><span class="p">:]</span>
+<a name="violations_test_file.py-6"></a><span class="hll"><span class="k">def</span> <span class="nf">func_2</span><span class="p">(</span><span class="n">spongebob</span><span class="p">,</span> <span class="n">squarepants</span><span class="p">):</span>
+</span><a name="violations_test_file.py-7"></a>    <span class="sd">&quot;&quot;&quot;A less messy function&quot;&quot;&quot;</span>
+<a name="violations_test_file.py-8"></a>    <span class="k">for</span> <span class="n">char</span> <span class="ow">in</span> <span class="n">spongebob</span><span class="p">:</span>
+<a name="violations_test_file.py-9"></a>        <span class="k">if</span> <span class="n">char</span> <span class="ow">in</span> <span class="n">squarepants</span><span class="p">:</span>
+<a name="violations_test_file.py-10"></a>            <span class="k">return</span> <span class="n">char</span>
+<a name="violations_test_file.py-11"></a><span class="hll">    <span class="n">unused</span><span class="o">=</span><span class="mi">1</span>
+</span><a name="violations_test_file.py-12"></a>    <span class="k">return</span> <span class="bp">None</span>
+</pre></div>
+</td></tr></table>
+            </div>
+        </div>
+    </body>
+</html>

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -421,6 +421,15 @@ class DiffQualityIntegrationTest(ToolsIntegrationBase):
             expected_status=0
         )
 
+    def test_html_with_external_css(self):
+        temp_dir = self._check_html_report(
+            'git_diff_violations.txt',
+            'pep8_violations_report_external_css.html',
+            ['diff-quality', '--violations=pep8'],
+            css_file='external_style.css'
+        )
+        self.assertTrue(os.path.exists(os.path.join(temp_dir, 'external_style.css')))
+
     def test_added_file_pep8_console(self):
         self._check_console_report(
             'git_diff_violations.txt',

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -58,7 +58,7 @@ class ToolsIntegrationBase(unittest.TestCase):
 
     def _clear_css(self, content):
         """
-        The CCS is provided by pygments and changes fairly often.
+        The CSS is provided by pygments and changes fairly often.
         Im ok with simply saying "There was css"
 
         Perhaps I will eat these words
@@ -67,7 +67,7 @@ class ToolsIntegrationBase(unittest.TestCase):
         assert len(content) > len(clean_content)
         return clean_content
 
-    def _check_html_report(self, git_diff_path, expected_html_path, tool_args, expected_status=0):
+    def _check_html_report(self, git_diff_path, expected_html_path, tool_args, expected_status=0, css_file=None):
         """
         Verify that the tool produces the expected HTML report.
 
@@ -92,16 +92,27 @@ class ToolsIntegrationBase(unittest.TestCase):
         self.addCleanup(lambda: shutil.rmtree(temp_dir))
         html_report_path = os.path.join(temp_dir, 'diff_coverage.html')
 
+        args = tool_args + ['--html-report', html_report_path]
+
+        if css_file:
+            css_file = os.path.join(temp_dir, css_file)
+            args += ['--external-css-file', css_file]
+
         # Execute the tool
-        code = main(tool_args + ['--html-report', html_report_path])
+        code = main(args)
         self.assertEquals(code, expected_status)
 
         # Check the HTML report
         with io.open(expected_html_path, encoding='utf-8') as expected_file:
             with io.open(html_report_path, encoding='utf-8') as html_report:
-                html = self._clear_css(html_report.read())
-                expected = self._clear_css(expected_file.read())
+                html = html_report.read()
+                expected = expected_file.read()
+                if css_file is None:
+                    html = self._clear_css(html)
+                    expected = self._clear_css(expected)
                 assert_long_str_equal(expected, html, strip=True)
+
+        return temp_dir
 
     def _check_console_report(self, git_diff_path, expected_console_path, tool_args, expected_status=0):
         """
@@ -339,6 +350,15 @@ class DiffCoverIntegrationTest(ToolsIntegrationBase):
             'unicode_html_report.html',
             ['diff-cover', 'unicode_coverage.xml']
         )
+
+    def test_html_with_external_css(self):
+        temp_dir = self._check_html_report(
+            'git_diff_external_css.txt',
+            'external_css_html_report.html',
+            ['diff-cover', 'coverage.xml'],
+            css_file='external_style.css'
+        )
+        self.assertTrue(os.path.exists(os.path.join(temp_dir, 'external_style.css')))
 
     def test_git_diff_error(self):
 

--- a/diff_cover/tool.py
+++ b/diff_cover/tool.py
@@ -26,6 +26,7 @@ from diff_cover.violationsreporters.violations_reporter import (
 
 COVERAGE_XML_HELP = "XML coverage report"
 HTML_REPORT_HELP = "Diff coverage HTML output"
+CSS_FILE_HELP = "Write CSS into an external file"
 COMPARE_BRANCH_HELP = "Branch to compare"
 VIOLATION_CMD_HELP = "Which code quality tool to use"
 INPUT_REPORTS_HELP = "Which reports reports to use"
@@ -56,9 +57,10 @@ def parse_coverage_args(argv):
         {
             'coverage_xml': COVERAGE_XML,
             'html_report': None | HTML_REPORT
+            'external_css_file': None | CSS_FILE
         }
 
-    where `COVERAGE_XML` is a path, and `HTML_REPORT` is a path.
+    where `COVERAGE_XML`, `HTML_REPORT`, and `CSS_FILE` are paths.
 
     The path strings may or may not exist.
     """
@@ -73,13 +75,23 @@ def parse_coverage_args(argv):
 
     parser.add_argument(
         '--html-report',
+        metavar='FILENAME',
         type=str,
         default=None,
         help=HTML_REPORT_HELP
     )
 
     parser.add_argument(
+        '--external-css-file',
+        metavar='FILENAME',
+        type=str,
+        default=None,
+        help=CSS_FILE_HELP,
+    )
+
+    parser.add_argument(
         '--compare-branch',
+        metavar='BRANCH',
         type=str,
         default='origin/master',
         help=COMPARE_BRANCH_HELP
@@ -87,6 +99,7 @@ def parse_coverage_args(argv):
 
     parser.add_argument(
         '--fail-under',
+        metavar='SCORE',
         type=float,
         default='0',
         help=FAIL_UNDER_HELP
@@ -172,7 +185,7 @@ def parse_quality_args(argv):
     return vars(parser.parse_args(argv))
 
 
-def generate_coverage_report(coverage_xml, compare_branch, html_report=None, ignore_unstaged=False):
+def generate_coverage_report(coverage_xml, compare_branch, html_report=None, css_file=None, ignore_unstaged=False):
     """
     Generate the diff coverage report, using kwargs from `parse_args()`.
     """
@@ -183,9 +196,15 @@ def generate_coverage_report(coverage_xml, compare_branch, html_report=None, ign
 
     # Build a report generator
     if html_report is not None:
-        reporter = HtmlReportGenerator(coverage, diff)
+        css_url = css_file
+        if css_url is not None:
+            css_url = os.path.relpath(css_file, os.path.dirname(html_report))
+        reporter = HtmlReportGenerator(coverage, diff, css_url=css_url)
         with open(html_report, "wb") as output_file:
             reporter.generate_report(output_file)
+        if css_file is not None:
+            with open(css_file, "wb") as output_file:
+                reporter.generate_css(output_file)
 
     reporter = StringReportGenerator(coverage, diff)
     output_file = sys.stdout if six.PY2 else sys.stdout.buffer
@@ -244,6 +263,7 @@ def main(argv=None, directory=None):
             arg_dict['coverage_xml'],
             arg_dict['compare_branch'],
             html_report=arg_dict['html_report'],
+            css_file=arg_dict['external_css_file'],
             ignore_unstaged=arg_dict['ignore_unstaged'],
         )
 

--- a/diff_cover/tool.py
+++ b/diff_cover/tool.py
@@ -57,7 +57,7 @@ def parse_coverage_args(argv):
         {
             'coverage_xml': COVERAGE_XML,
             'html_report': None | HTML_REPORT,
-            'external_css_file': None | CSS_FILE
+            'external_css_file': None | CSS_FILE,
         }
 
     where `COVERAGE_XML`, `HTML_REPORT`, and `CSS_FILE` are paths.
@@ -121,9 +121,9 @@ def parse_quality_args(argv):
     valid options:
 
         {
-            'violations': pep8 | pyflakes | flake8 | pylint
+            'violations': pep8 | pyflakes | flake8 | pylint | ...,
             'html_report': None | HTML_REPORT,
-            'external_css_file': None | CSS_FILE
+            'external_css_file': None | CSS_FILE,
         }
 
     where `HTML_REPORT` and `CSS_FILE` are paths.


### PR DESCRIPTION
Fixes #34.

This is a prototype that I expect to need to fix before it gets merged.

Missing bits:
- [x] diff-quality should probably also support --external-css-file
- [x] tests

I'm also not very fond of duplicating some CSS rules between external-style.css and snippet_style.html.

Test plan:

- ran `tox` (tried `detox`, but your test suite doesn't support parallel execution due to writing to the same hardcoded filenames!)
- installed it locally (`virtualenv .venv && .venv/bin/pip install -e .`)
- ran `.venv/bin/diff-cover coverage.xml --html /tmp/diff-cover.html --external-css /tmp/diff-cover.css`
- inspected `/tmp/diff-cover.*` with a text editor and tried it out in a browser