### PR TITLE
Use correct report driver command for flake8

### DIFF
--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -216,7 +216,7 @@ pyflakes_driver = RegexBasedDriver(
 flake8_driver = RegexBasedDriver(
     name='flake8',
     supported_extensions=['py'],
-    command=['pyflakes'],
+    command=['flake8'],
     # Match lines of the form:
     # path/to/file.py:328: undefined name '_thing'
     # path/to/file.py:418: 'random' imported but unused


### PR DESCRIPTION
Before when I ran command:

 `diff-quality --violations=flake8 --options=--config=.flake8rc --fail-under=100`

got error:

```
diff_cover.command_runner.CommandError: Usage: pyflakes [options]

pyflakes: error: no such option: --config
```
Because using `pyflakes`, which doesn't have this option, instead of `flake8`.