### PR TITLE
Fix git-diff with `mnemonicprefix` option

### DIFF
--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -27,7 +27,7 @@ class GitDiffTool(object):
         to stderr.
         """
         return execute([
-            'git', 'diff',
+            'git', '-c', 'diff.mnemonicprefix=no', 'diff',
             "{branch}...HEAD".format(branch=compare_branch),
             '--no-color',
             '--no-ext-diff'
@@ -41,7 +41,8 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return execute(['git', 'diff', '--no-color', '--no-ext-diff'])[0]
+        return execute(['git', '-c', 'diff.mnemonicprefix=no', 'diff',
+                        '--no-color', '--no-ext-diff'])[0]
 
     def diff_staged(self):
         """
@@ -51,4 +52,5 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return execute(['git', 'diff', '--cached', '--no-color', '--no-ext-diff'])[0]
+        return execute(['git', '-c', 'diff.mnemonicprefix=no', 'diff',
+                        '--cached', '--no-color', '--no-ext-diff'])[0]

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -26,7 +26,8 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', 'origin/master...HEAD', '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff',
+                    'origin/master...HEAD', '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -39,7 +40,8 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff',
+                    '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -52,7 +54,8 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', '--cached', '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff', '--cached',
+                    '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -67,7 +70,8 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', 'diff', 'release...HEAD', '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff',
+                    'release...HEAD', '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -166,7 +166,7 @@ class ToolsIntegrationBase(unittest.TestCase):
         a phony directory.
         """
         def patch_diff(command, **kwargs):
-            if command[0:2] == ['git', 'diff']:
+            if command[0:4] == ['git', '-c', 'diff.mnemonicprefix=no', 'diff']:
                 mock = Mock()
                 mock.communicate.return_value = (stdout, stderr)
                 return mock


### PR DESCRIPTION
With `diff.mnemonicprefix`, the prefixes would not be just `a` and `b`,
and therefore the regexp would not match.

This could be improved further by making `git` not use any user
configuration, e.g. by setting `$HOME` to `/dev/null`.

This follows up on #20, but without the refactoring.