### PR TITLE
Move logging configuration to main().

### DIFF
--- a/diff_cover/tool.py
+++ b/diff_cover/tool.py
@@ -260,6 +260,8 @@ def main(argv=None, directory=None):
     1 is an error
     0 is successful run
     """
+    logging.basicConfig(format='%(message)s')
+
     argv = argv or sys.argv
     # Init the path tool to work with the specified directory,
     # or the current directory if it isn't set.
@@ -348,5 +350,4 @@ def main(argv=None, directory=None):
         assert False, 'Expect diff-cover or diff-quality in {0}'.format(name)
 
 if __name__ == "__main__":
-    logging.basicConfig(format='%(message)s')
     exit(main())


### PR DESCRIPTION
The problem with the current code is that it fails w/ the following message when `diff-cover` tool is executed after fresh installation:

```
% diff-cover coverage/coverage.xml
No handlers could be found for logger "diff_cover.tool"
```

The reason is that the default logger [is configured at the module level, when the `diff_cover.tool` is executed as a standalone script](https://github.com/Bachmann1234/diff-cover/blob/master/diff_cover/tool.py#L351):

```python
if __name__ == "__main__":
    logging.basicConfig(format='%(message)s')
    exit(main())
```

However the script that is present in `bin` after installation using `pip install diff-cover==0.9.6` imports the `main` function, which doesn't contain the `basicConfig` call.

Also, in https://github.com/Bachmann1234/diff-cover/issues/42, it was suggested that `basicConfig` call is moved to the `main`.

Alternative would be to perform logger configuration in `bin/diff-cover`, if there's a reason not to place it in `main`?