### PR TITLE
Fix two issues with ESLint integration

### DIFF
--- a/diff_cover/violationsreporters/base.py
+++ b/diff_cover/violationsreporters/base.py
@@ -7,6 +7,7 @@ import copy
 
 import re
 import sys
+import os
 
 
 from diff_cover.command_runner import execute, run_command_for_code
@@ -208,6 +209,8 @@ class RegexBasedDriver(QualityDriver):
                 # Ignore any line that isn't a violation
                 if match is not None:
                     src, line_number, message = match.groups()
+                    # Transform src to a relative path, if it isn't already
+                    src = os.path.relpath(src)
                     violation = Violation(int(line_number), message)
                     violations_dict[src].append(violation)
 

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -237,7 +237,7 @@ jshint_driver = RegexBasedDriver(
 eslint_driver = RegexBasedDriver(
     name='eslint',
     supported_extensions=['js'],
-    command=['eslint', '--format compact'],
+    command=['eslint', '--format=compact'],
     expression=r'^([^:]+): line (\d+), col \d+, (.*)$',
     command_to_check_install=['eslint', '-v'],
 )


### PR DESCRIPTION
Hey there - I'm a JS developer at edX and we're working on migrating from JSHint to ESLint. To get diff-cover working with eslint version 2.13 I had to make two modifications:

1. ESLint's `compact` reporter returns the absolute path of filenames containing lint issues, rather than the relative path (which it seems like most of the other reporters integrated use). I added a line in the violations reporter that transforms the path parsed from the file to a relative path, if it isn't one already.

2. The method in which options were passed to ESLint (`--format simple`) was resulting in an ESLint CLI syntax error. (Strangely, `eslint --format compact .` from the command line works, but doing this through popen (`subprocess.Popen(['eslint', '--format compact', '.'])`) fails and just shows the ESLint help text.) This was just fixed by more closely following the bash longform arguments syntax: `--format=simple`. 

cc @agroszer, who it looks like was involved in this code, and @benpatterson and @cpennington who've expressed interest in this work.