### PR TITLE
I'd like to be able to use next-error and previous-error in Emacs with diff-cover's output

### DIFF
--- a/diff_cover/templates/console_quality_report.txt
+++ b/diff_cover/templates/console_quality_report.txt
@@ -8,7 +8,7 @@ Diff: {{ diff_name }}
 {% if stats.percent_covered < 100 %}
 {{ src_path }} ({{ stats.percent_covered|round(1) }}%):
 {% for line, message in stats.violations %}
-    {{ line }}: {{ message }}
+{{ src_path }}:{{ line }}: {{ message }}
 {% endfor %}
 {% else %}
 {{ src_path }} (100%)

--- a/diff_cover/tests/fixtures/pycodestyle_violations_report.txt
+++ b/diff_cover/tests/fixtures/pycodestyle_violations_report.txt
@@ -4,9 +4,9 @@ Quality Report: pycodestyle
 Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (66.7%):
-    2: E225 missing whitespace around operator
-    6: E302 expected 2 blank lines, found 0
-    11: E225 missing whitespace around operator
+violations_test_file.py:2: E225 missing whitespace around operator
+violations_test_file.py:6: E302 expected 2 blank lines, found 0
+violations_test_file.py:11: E225 missing whitespace around operator
 -------------
 Total:   9 lines
 Violations: 3 lines

--- a/diff_cover/tests/fixtures/pyflakes_two_files.txt
+++ b/diff_cover/tests/fixtures/pyflakes_two_files.txt
@@ -4,9 +4,9 @@ Quality Report: pyflakes
 Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 hello.py (0.0%):
-    2: undefined name 'unknown_var'
+hello.py:2: undefined name 'unknown_var'
 hi.py (0.0%):
-    2: undefined name 'unknown_var'
+hi.py:2: undefined name 'unknown_var'
 -------------
 Total:   2 lines
 Violations: 2 lines

--- a/diff_cover/tests/fixtures/pyflakes_violations_report.txt
+++ b/diff_cover/tests/fixtures/pyflakes_violations_report.txt
@@ -4,7 +4,7 @@ Quality Report: pyflakes
 Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (88.9%):
-    11: local variable 'unused' is assigned to but never used
+violations_test_file.py:11: local variable 'unused' is assigned to but never used
 -------------
 Total:   9 lines
 Violations: 1 line

--- a/diff_cover/tests/fixtures/pylint_dupe_violations_report.txt
+++ b/diff_cover/tests/fixtures/pylint_dupe_violations_report.txt
@@ -4,7 +4,7 @@ Quality Report: pylint
 Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 fileone.py (93.8%):
-    3: R0801: (duplicate-code), : Similar lines in 2 files
+fileone.py:3: R0801: (duplicate-code), : Similar lines in 2 files
 -------------
 Total:   16 lines
 Violations: 1 line

--- a/diff_cover/tests/fixtures/pylint_violations_console_report.txt
+++ b/diff_cover/tests/fixtures/pylint_violations_console_report.txt
@@ -4,11 +4,11 @@ Quality Report: pylint
 Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (66.7%):
-    1: C0111: (missing-docstring), : Missing module docstring
-    1: C0111: (missing-docstring), func_1: Missing function docstring
-    2: C0326: (bad-whitespace), : Exactly one space required around comparison
-    11: C0326: (bad-whitespace), : Exactly one space required around assignment
-    11: W0612: (unused-variable), func_2: Unused variable 'unused'
+violations_test_file.py:1: C0111: (missing-docstring), : Missing module docstring
+violations_test_file.py:1: C0111: (missing-docstring), func_1: Missing function docstring
+violations_test_file.py:2: C0326: (bad-whitespace), : Exactly one space required around comparison
+violations_test_file.py:11: C0326: (bad-whitespace), : Exactly one space required around assignment
+violations_test_file.py:11: W0612: (unused-variable), func_2: Unused variable 'unused'
 -------------
 Total:   9 lines
 Violations: 3 lines

--- a/diff_cover/tests/fixtures/pylint_violations_report.txt
+++ b/diff_cover/tests/fixtures/pylint_violations_report.txt
@@ -4,9 +4,9 @@ Quality Report: pylint
 Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (77.8%):
-    1: C0111: Missing docstring
-    1: C0111: func_1: Missing docstring
-    2: C0322: func_1: Operator not preceded by a space
+violations_test_file.py:1: C0111: Missing docstring
+violations_test_file.py:1: C0111: func_1: Missing docstring
+violations_test_file.py:2: C0322: func_1: Operator not preceded by a space
 -------------
 Total:   9 lines
 Violations: 2 lines

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,7 +2,7 @@
 mock
 nose
 coverage
-pycodestyle
+pycodestyle<2.4.0
 flake8
 pyflakes
 pylint


### PR DESCRIPTION
This is similar to `-f parseable` from pylint - which, oddly, diff-cover appears to require although it can't output :)
