### PR TITLE
Filter files in diff on provided extension in diff-quality

### DIFF
--- a/diff_cover/tests/test_diff_reporter.py
+++ b/diff_cover/tests/test_diff_reporter.py
@@ -64,6 +64,27 @@ class GitDiffReporterTest(unittest.TestCase):
         self.assertEqual(len(source_paths), 1)
         self.assertEqual('subdir/file1.py', source_paths[0])
 
+    def test_git_source_paths_with_supported_extensions(self):
+
+        # Configure the git diff output
+        self._set_git_diff_output(
+            git_diff_output({'subdir/file1.py': line_numbers(3, 10) + line_numbers(34, 47)}),
+            git_diff_output({'subdir/file2.py': line_numbers(3, 10), 'file3.py': [0]}),
+            git_diff_output({'README.md': line_numbers(3, 10)})
+        )
+
+        # Set supported extensions
+        self.diff._supported_extensions = ['py']
+
+        # Get the source paths in the diff
+        source_paths = self.diff.src_paths_changed()
+
+        # Validate the source paths, README.md should be left out
+        self.assertEqual(len(source_paths), 3)
+        self.assertEqual('file3.py', source_paths[0])
+        self.assertEqual('subdir/file1.py', source_paths[1])
+        self.assertEqual('subdir/file2.py', source_paths[2])
+
     def test_git_lines_changed(self):
 
         # Configure the git diff output

--- a/diff_cover/tool.py
+++ b/diff_cover/tool.py
@@ -231,7 +231,7 @@ def generate_quality_report(tool, compare_branch, html_report=None, css_file=Non
     """
     Generate the quality report, using kwargs from `parse_args()`.
     """
-    diff = GitDiffReporter(compare_branch, git_diff=GitDiffTool(), ignore_unstaged=ignore_unstaged)
+    diff = GitDiffReporter(compare_branch, git_diff=GitDiffTool(), ignore_unstaged=ignore_unstaged, supported_extensions=tool.driver.supported_extensions)
 
     if html_report is not None:
         css_url = css_file


### PR DESCRIPTION
Diff-quality used all files in the diff to determine the quality %. This resulted in artificially high quality percentages when a diff contained other files than the ones provided in the supported extensions list for the RegexBasedDriver.

Still not perfect, since files with the supported extension, that have not been analyzed by the lint tool, are still used to determine the quality percentage. For this to work, something like the checkstyle xml format should be used/supported, since it contains a list of all files that were processed by the lint tool (so also the files w/o any violations). Using the intersection of the diff with this list, results in the most accurate list for this, I think.