### PR TITLE
Add ignore_staged option

### DIFF
--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -61,17 +61,17 @@ class GitDiffReporter(BaseDiffReporter):
         for the `git diff` tool.  (Should have same interface
         as `git_diff.GitDiffTool`)
         """
-        options = ["{0}...HEAD".format(compare_branch)]
+        options = list()
         if not ignore_staged:
             options.append("staged")
         if not ignore_unstaged:
             options.append("unstaged")
 
         # Branch is always present, so use as basis for name
-        name = options[0]
-        if len(options) > 1:
+        name = "{0}...HEAD".format(compare_branch)
+        if len(options) > 0:
             # If more options are present separate them by comma's, except the last one
-            for item in options[1:-1]:
+            for item in options[:-1]:
                 name += ", " + item
             # Apply and + changes to the last option
             name += " and " + options[-1] + " changes"

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -55,17 +55,32 @@ class GitDiffReporter(BaseDiffReporter):
     Query information from a Git diff between branches.
     """
 
-    def __init__(self, compare_branch='origin/master', git_diff=None, ignore_unstaged=None, supported_extensions=None):
+    def __init__(self, compare_branch='origin/master', git_diff=None, ignore_staged=None, ignore_unstaged=None, supported_extensions=None):
         """
         Configure the reporter to use `git_diff` as the wrapper
         for the `git diff` tool.  (Should have same interface
         as `git_diff.GitDiffTool`)
         """
-        name = "{branch}...HEAD, staged, and unstaged changes".format(branch=compare_branch)
+        options = ["{0}...HEAD".format(compare_branch)]
+        if not ignore_staged:
+            options.append("staged")
+        if not ignore_unstaged:
+            options.append("unstaged")
+
+        # Branch is always present, so use as basis for name
+        name = options[0]
+        if len(options) > 1:
+            # If more options are present separate them by comma's, except the last one
+            for item in options[1:-1]:
+                name += ", " + item
+            # Apply and + changes to the last option
+            name += ", and " + options[-1] + " changes"
+
         super(GitDiffReporter, self).__init__(name)
 
         self._compare_branch = compare_branch
         self._git_diff_tool = git_diff
+        self._ignore_staged = ignore_staged
         self._ignore_unstaged = ignore_unstaged
         self._supported_extensions = supported_extensions
 
@@ -107,8 +122,9 @@ class GitDiffReporter(BaseDiffReporter):
         """
         Return a list of stages to be included in the diff results.
         """
-        included = [self._git_diff_tool.diff_committed(self._compare_branch),
-                    self._git_diff_tool.diff_staged()]
+        included = [self._git_diff_tool.diff_committed(self._compare_branch)]
+        if not self._ignore_staged:
+            included.append(self._git_diff_tool.diff_staged())
         if not self._ignore_unstaged:
             included.append(self._git_diff_tool.diff_unstaged())
 

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -74,7 +74,7 @@ class GitDiffReporter(BaseDiffReporter):
             for item in options[1:-1]:
                 name += ", " + item
             # Apply and + changes to the last option
-            name += ", and " + options[-1] + " changes"
+            name += " and " + options[-1] + " changes"
 
         super(GitDiffReporter, self).__init__(name)
 

--- a/diff_cover/tests/fixtures/add_console_report.txt
+++ b/diff_cover/tests/fixtures/add_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/add_html_report.html
+++ b/diff_cover/tests/fixtures/add_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/fixtures/changed_console_report.txt
+++ b/diff_cover/tests/fixtures/changed_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 test_src.txt (100%)
 -------------

--- a/diff_cover/tests/fixtures/changed_html_report.html
+++ b/diff_cover/tests/fixtures/changed_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 1 line</li>
             <li><b>Missing</b>: 0 lines</li>

--- a/diff_cover/tests/fixtures/delete_console_report.txt
+++ b/diff_cover/tests/fixtures/delete_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 No lines with coverage information in this diff.
 -------------

--- a/diff_cover/tests/fixtures/delete_html_report.html
+++ b/diff_cover/tests/fixtures/delete_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <p>No lines with coverage information in this diff.</p>
     </body>
 </html>

--- a/diff_cover/tests/fixtures/dotnet_coverage_console_report.txt
+++ b/diff_cover/tests/fixtures/dotnet_coverage_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 SampleApp/Sample.cs (0.0%): Missing lines 23-25
 -------------

--- a/diff_cover/tests/fixtures/empty_pep8_violations.txt
+++ b/diff_cover/tests/fixtures/empty_pep8_violations.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pep8
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (100%)
 -------------

--- a/diff_cover/tests/fixtures/external_css_html_report.html
+++ b/diff_cover/tests/fixtures/external_css_html_report.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 1 line</li>
             <li><b>Missing</b>: 0 lines</li>

--- a/diff_cover/tests/fixtures/lua_console_report.txt
+++ b/diff_cover/tests/fixtures/lua_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 scripts/maths.lua (50.0%): Missing lines 12
 -------------

--- a/diff_cover/tests/fixtures/moved_console_report.txt
+++ b/diff_cover/tests/fixtures/moved_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/moved_html_report.html
+++ b/diff_cover/tests/fixtures/moved_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/fixtures/mult_inputs_console_report.txt
+++ b/diff_cover/tests/fixtures/mult_inputs_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 test_src.txt (60.0%): Missing lines 4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/mult_inputs_html_report.html
+++ b/diff_cover/tests/fixtures/mult_inputs_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 4 lines</li>

--- a/diff_cover/tests/fixtures/pep8_violations_report.html
+++ b/diff_cover/tests/fixtures/pep8_violations_report.html
@@ -77,7 +77,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pep8</p>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pep8_violations_report.txt
+++ b/diff_cover/tests/fixtures/pep8_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pep8
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (66.7%):
     2: E225 missing whitespace around operator

--- a/diff_cover/tests/fixtures/pep8_violations_report_external_css.html
+++ b/diff_cover/tests/fixtures/pep8_violations_report_external_css.html
@@ -8,7 +8,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pep8</p>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pyflakes_two_files.txt
+++ b/diff_cover/tests/fixtures/pyflakes_two_files.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pyflakes
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 hello.py (0.0%):
     2: undefined name 'unknown_var'

--- a/diff_cover/tests/fixtures/pyflakes_violations_report.html
+++ b/diff_cover/tests/fixtures/pyflakes_violations_report.html
@@ -77,7 +77,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pyflakes</p>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pyflakes_violations_report.txt
+++ b/diff_cover/tests/fixtures/pyflakes_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pyflakes
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (88.9%):
     11: local variable 'unused' is assigned to but never used

--- a/diff_cover/tests/fixtures/pylint_dupe_violations_report.txt
+++ b/diff_cover/tests/fixtures/pylint_dupe_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pylint
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 fileone.py (93.8%):
     3: R0801: (duplicate-code), : Similar lines in 2 files

--- a/diff_cover/tests/fixtures/pylint_violations_console_report.txt
+++ b/diff_cover/tests/fixtures/pylint_violations_console_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pylint
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (66.7%):
     1: C0111: (missing-docstring), : Missing module docstring

--- a/diff_cover/tests/fixtures/pylint_violations_report.html
+++ b/diff_cover/tests/fixtures/pylint_violations_report.html
@@ -77,7 +77,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pylint</p>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pylint_violations_report.txt
+++ b/diff_cover/tests/fixtures/pylint_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pylint
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (77.8%):
     1: C0111: Missing docstring

--- a/diff_cover/tests/fixtures/subdir_coverage_console_report.txt
+++ b/diff_cover/tests/fixtures/subdir_coverage_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 sub/test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/subdir_coverage_html_report.html
+++ b/diff_cover/tests/fixtures/subdir_coverage_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/fixtures/unicode_console_report.txt
+++ b/diff_cover/tests/fixtures/unicode_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged, and unstaged changes
+Diff: origin/master...HEAD, staged and unstaged changes
 -------------
 unicode_test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/unicode_html_report.html
+++ b/diff_cover/tests/fixtures/unicode_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged, and unstaged changes</p>
+        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/test_diff_reporter.py
+++ b/diff_cover/tests/test_diff_reporter.py
@@ -31,6 +31,27 @@ class GitDiffReporterTest(unittest.TestCase):
             'release...HEAD, staged, and unstaged changes'
         )
 
+    def test_name_ignore_staged(self):
+        # Override the default branch
+        self.assertEqual(
+            GitDiffReporter(git_diff=self._git_diff, ignore_staged=True).name(),
+            'origin/master...HEAD, and unstaged changes'
+        )
+
+    def test_name_ignore_unstaged(self):
+        # Override the default branch
+        self.assertEqual(
+            GitDiffReporter(git_diff=self._git_diff, ignore_unstaged=True).name(),
+            'origin/master...HEAD, and staged changes'
+        )
+
+    def test_name_ignore_staged_and_unstaged(self):
+        # Override the default branch
+        self.assertEqual(
+            GitDiffReporter(git_diff=self._git_diff, ignore_staged=True, ignore_unstaged=True).name(),
+            'origin/master...HEAD'
+        )
+
     def test_git_source_paths(self):
 
         # Configure the git diff output
@@ -407,6 +428,15 @@ class GitDiffReporterTest(unittest.TestCase):
         self.assertEqual(3, len(self.diff._get_included_diff_results()))
         self.assertEqual(['', '', unstaged_input], self.diff._get_included_diff_results())
 
+    def test_ignore_staged_inclusion(self):
+        self.diff = GitDiffReporter(git_diff=self._git_diff, ignore_staged=True)
+
+        staged_input = git_diff_output({'subdir/file1.py': line_numbers(3, 10) + line_numbers(34, 47)})
+        self._set_git_diff_output('', staged_input, '')
+
+        self.assertEqual(2, len(self.diff._get_included_diff_results()))
+        self.assertEqual(['', ''], self.diff._get_included_diff_results())
+
     def test_ignore_unstaged_inclusion(self):
         self.diff = GitDiffReporter(git_diff=self._git_diff, ignore_unstaged=True)
 
@@ -415,6 +445,17 @@ class GitDiffReporterTest(unittest.TestCase):
 
         self.assertEqual(2, len(self.diff._get_included_diff_results()))
         self.assertEqual(['', ''], self.diff._get_included_diff_results())
+
+
+    def test_ignore_staged_and_unstaged_inclusion(self):
+        self.diff = GitDiffReporter(git_diff=self._git_diff, ignore_staged=True, ignore_unstaged=True)
+
+        staged_input = git_diff_output({'subdir/file1.py': line_numbers(3, 10) + line_numbers(34, 47)})
+        unstaged_input = git_diff_output({'subdir/file2.py': line_numbers(3, 10) + line_numbers(34, 47)})
+        self._set_git_diff_output('', staged_input, unstaged_input)
+
+        self.assertEqual(1, len(self.diff._get_included_diff_results()))
+        self.assertEqual([''], self.diff._get_included_diff_results())
 
     def _set_git_diff_output(self, committed_diff,
                              staged_diff, unstaged_diff):

--- a/diff_cover/tests/test_diff_reporter.py
+++ b/diff_cover/tests/test_diff_reporter.py
@@ -21,28 +21,28 @@ class GitDiffReporterTest(unittest.TestCase):
 
         # Expect that diff report is named after its compare branch
         self.assertEqual(
-            self.diff.name(), 'origin/master...HEAD, staged, and unstaged changes'
+            self.diff.name(), 'origin/master...HEAD, staged and unstaged changes'
         )
 
     def test_name_compare_branch(self):
         # Override the default branch
         self.assertEqual(
             GitDiffReporter(git_diff=self._git_diff, compare_branch='release').name(),
-            'release...HEAD, staged, and unstaged changes'
+            'release...HEAD, staged and unstaged changes'
         )
 
     def test_name_ignore_staged(self):
         # Override the default branch
         self.assertEqual(
             GitDiffReporter(git_diff=self._git_diff, ignore_staged=True).name(),
-            'origin/master...HEAD, and unstaged changes'
+            'origin/master...HEAD and unstaged changes'
         )
 
     def test_name_ignore_unstaged(self):
         # Override the default branch
         self.assertEqual(
             GitDiffReporter(git_diff=self._git_diff, ignore_unstaged=True).name(),
-            'origin/master...HEAD, and staged changes'
+            'origin/master...HEAD and staged changes'
         )
 
     def test_name_ignore_staged_and_unstaged(self):


### PR DESCRIPTION
In case you don't want to mark staged changes as violations (for example when checking the result of a merge with --no-commit).

Also changed the generation of the name of the diff generator to represent the active ignore options. This results in a different name pattern, so could cause trouble with automated checking of results (too strict regex for example). The removal of the second comma probably has the biggest impact, so is in a separate commit, so could be reverted.