### PR TITLE
fixed encoding detecting error

### DIFF
--- a/diff_cover/snippets.py
+++ b/diff_cover/snippets.py
@@ -9,6 +9,7 @@ from pygments.lexers import guess_lexer_for_filename
 from pygments.lexers.special import TextLexer
 from pygments.util import ClassNotFound
 import six
+import chardet
 
 from diff_cover.git_path import GitPathTool
 # If tokenize.open (Python>=3.2) is available, use that to open python files.
@@ -24,7 +25,9 @@ except ImportError:
         # The following is copied from tokenize.py in Python 3.2,
         # Copyright (c) 2001-2014 Python Software Foundation; All Rights Reserved
         buffer = io.open(filename, 'rb')
-        encoding, lines = detect_encoding(buffer.readline)
+        raw_data = buffer.read()
+        result = chardet.detect(raw_data)
+        encoding = result['encoding']
         buffer.seek(0)
         text = io.TextIOWrapper(buffer, encoding, line_buffering=True)
         text.mode = 'r'


### PR DESCRIPTION
this patch is for this error, please take a look, thanks.
```
Traceback (most recent call last):
  File "c:\python27\Lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "c:\python27\Lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "D:\virtualenv\Scripts\diff-cover.exe\__main__.py", line 9, in <module>
  File "d:\virtualenv\lib\site-packages\diff_cover\tool.py", line 303, in main
    ignore_unstaged=arg_dict['ignore_unstaged'],
  File "d:\virtualenv\lib\site-packages\diff_cover\tool.py", line 232, in generate_coverage_report
    reporter.generate_report(output_file)
  File "d:\virtualenv\lib\site-packages\diff_cover\report_generator.py", line 216, in generate_report
    report = template.render(self._context())
  File "d:\virtualenv\lib\site-packages\diff_cover\report_generator.py", line 260, in _context
    (src, self._src_path_stats(src)) for src in self.src_paths()
  File "d:\virtualenv\lib\site-packages\diff_cover\report_generator.py", line 260, in <genexpr>
    (src, self._src_path_stats(src)) for src in self.src_paths()
  File "d:\virtualenv\lib\site-packages\diff_cover\report_generator.py", line 323, in _src_path_stats
    snippets = Snippet.load_snippets_html(src_path, violation_lines)
  File "d:\virtualenv\lib\site-packages\diff_cover\snippets.py", line 137, in load_snippets_html
    snippet_list = cls.load_snippets(src_path, violation_lines)
  File "d:\virtualenv\lib\site-packages\diff_cover\snippets.py", line 155, in load_snippets
    contents = src_file.read()
  File "d:\virtualenv\lib\codecs.py", line 314, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf8' codec can't decode bytes in position 9494-9495: invalid continuation byte
```