### PR TITLE
make tests pass on master

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,7 +2,7 @@
 mock
 nose
 coverage
-pycodestyle
+pycodestyle<2.4.0
 flake8
 pyflakes
 pylint


### PR DESCRIPTION
The combination of these two bugs:

- https://github.com/PyCQA/pycodestyle/issues/741
- https://github.com/pypa/pip/issues/988

mean that in the test environment a bad version of pycodestyle gets installed which breaks flake8, but since pip doesn't track version constraints, it just gets paved over.

this makes the tests pass again on master.