### PR TITLE
Strip the source property of trailing and leading whitespace

### DIFF
--- a/diff_cover/tests/fixtures/dotnet_coverage.xml
+++ b/diff_cover/tests/fixtures/dotnet_coverage.xml
@@ -3,7 +3,9 @@
 <coverage line-rate="0.75" branch-rate="1" lines-covered="9" lines-valid="12" branches-covered="0" branches-valid="0" complexity="0" version="0" timestamp="1410969572">
   <sources>
     <source>--source</source>
-    <source>/code/samplediff/SampleApp</source>
+    <source>
+      /code/samplediff/SampleApp 
+    </source>
   </sources>
   <packages>
     <package name="SampleApp" line-rate="0.75" branch-rate="1" complexity="0">

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -84,7 +84,7 @@ class XmlCoverageReporter(BaseViolationReporter):
              src_abs_path in [
                  self._to_unix_path(
                      os.path.join(
-                         source,
+                         source.strip(),
                          clazz.get('filename')
                      )
                  ) for source in sources]]


### PR DESCRIPTION
https://github.com/Bachmann1234/diff-cover/issues/77 

.strip(' \t\n\r') was suggested in the issue but the default should be fine.