### PR TITLE
Enforce noprefix=no for git diff config

### DIFF
--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -27,8 +27,10 @@ class GitDiffTool(object):
         to stderr.
         """
         return execute([
-            'git', '-c', 'diff.mnemonicprefix=no', 'diff',
-            "{branch}...HEAD".format(branch=compare_branch),
+            'git',
+            '-c', 'diff.mnemonicprefix=no',
+            '-c', 'diff.noprefix=no',
+            'diff', '{branch}...HEAD'.format(branch=compare_branch),
             '--no-color',
             '--no-ext-diff'
         ])[0]
@@ -41,8 +43,14 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return execute(['git', '-c', 'diff.mnemonicprefix=no', 'diff',
-                        '--no-color', '--no-ext-diff'])[0]
+        return execute([
+            'git',
+            '-c', 'diff.mnemonicprefix=no',
+            '-c', 'diff.noprefix=no',
+            'diff',
+            '--no-color',
+            '--no-ext-diff'
+        ])[0]
 
     def diff_staged(self):
         """
@@ -52,5 +60,12 @@ class GitDiffTool(object):
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.
         """
-        return execute(['git', '-c', 'diff.mnemonicprefix=no', 'diff',
-                        '--cached', '--no-color', '--no-ext-diff'])[0]
+        return execute([
+            'git',
+            '-c', 'diff.mnemonicprefix=no',
+            '-c', 'diff.noprefix=no',
+            'diff',
+            '--cached',
+            '--no-color',
+            '--no-ext-diff'
+        ])[0]

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -27,8 +27,9 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff',
-                    'origin/master...HEAD', '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
+                    'diff.noprefix=no', 'diff', 'origin/master...HEAD',
+                    '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -41,8 +42,8 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff',
-                    '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
+                    'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -55,8 +56,9 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff', '--cached',
-                    '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
+                    'diff.noprefix=no', 'diff', '--cached', '--no-color',
+                    '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -71,8 +73,9 @@ class TestGitDiffTool(unittest.TestCase):
         self.assertEqual(output, 'test output')
 
         # Expect that the correct command was executed
-        expected = ['git', '-c', 'diff.mnemonicprefix=no', 'diff',
-                    'release...HEAD', '--no-color', '--no-ext-diff']
+        expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
+                    'diff.noprefix=no', 'diff', 'release...HEAD', '--no-color',
+                    '--no-ext-diff']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -166,7 +166,8 @@ class ToolsIntegrationBase(unittest.TestCase):
         a phony directory.
         """
         def patch_diff(command, **kwargs):
-            if command[0:4] == ['git', '-c', 'diff.mnemonicprefix=no', 'diff']:
+            if command[0:6] == ['git', '-c', 'diff.mnemonicprefix=no', '-c',
+                                'diff.noprefix=no', 'diff']:
                 mock = Mock()
                 mock.communicate.return_value = (stdout, stderr)
                 mock.returncode = returncode


### PR DESCRIPTION
Fixes #93.

I tried to make the `execute` args break semantically, let me know if you prefer to just let them flow to fill the available space instead. :)

Note that I tried to run the tests but got a lot of unrelated failures when running `tox`; specifically `nose` failed to run.

This was the error:

```
py37 runtests: commands[0] | coverage run -m nose
........usage: python -m nose [-h] --violations TOOL [--html-report FILENAME]
                      [--external-css-file FILENAME] [--compare-branch BRANCH]
                      [--options [OPTIONS]] [--fail-under SCORE]
                      [--ignore-staged] [--ignore-unstaged]
                      [--exclude EXCLUDE [EXCLUDE ...]]
                      [input_reports [input_reports ...]]
python -m nose: error: the following arguments are required: --violations
usage: python -m nose [-h] --violations TOOL [--html-report FILENAME]
                      [--external-css-file FILENAME] [--compare-branch BRANCH]
                      [--options [OPTIONS]] [--fail-under SCORE]
                      [--ignore-staged] [--ignore-unstaged]
                      [--exclude EXCLUDE [EXCLUDE ...]]
                      [input_reports [input_reports ...]]
python -m nose: error: the following arguments are required: --violations
```