### PR TITLE
Ensure case is normalized on Windows when comparing paths from XML coverage report

### DIFF
--- a/diff_cover/tests/test_violations_reporter.py
+++ b/diff_cover/tests/test_violations_reporter.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import os
 import subprocess
+import sys
 import xml.etree.cElementTree as etree
 from subprocess import Popen
 from textwrap import dedent
@@ -345,6 +346,16 @@ class XmlCoverageReporterTest(unittest.TestCase):
                 line.set('number', str(line_num))
 
         return root
+
+    def test_to_unix_path(self):
+        """
+        Ensure the _to_unix_path static function handles paths properly.
+        """
+        to_unix_path = XmlCoverageReporter._to_unix_path
+        self.assertEqual(to_unix_path('foo/bar'), 'foo/bar')
+        self.assertEqual(to_unix_path('foo\\bar'), 'foo/bar')
+        if sys.platform.startswith('win'):
+            self.assertEqual(to_unix_path('FOO\\bar'), 'foo/bar')
 
 
 class CloverXmlCoverageReporterTest(unittest.TestCase):

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -46,7 +46,7 @@ class XmlCoverageReporter(BaseViolationReporter):
         :param path: string of the path to convert
         :return: the unix version of that path
         """
-        return posixpath.normpath(path.replace("\\", '/'))
+        return posixpath.normpath(os.path.normcase(path).replace("\\", '/'))
 
     def _get_classes(self, xml_document, src_path):
         """


### PR DESCRIPTION
This fixes a subtle problem on Windows, which is case-preserving but case-insensitive.

Depending from where the user executed the coverage command to produce the XML file, the `<sources>` tag might contain a different case in the drive letter: `w:\foo\bar` vs `W:\foo\bar` (note the case of the first letter). On Windows both paths should be considered the same.

This patch calls the `os.path.normcase` function, which changes all paths to lower-case on Windows and is a noop on Linux.

I experienced this problem myself and with this patch this fixes the issue for me.