### PR TITLE
Switch to using pytest as test runner

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,15 +71,13 @@ Getting Started
 1. Set the current working directory to a ``git`` repository.
 
 2. Run your test suite under coverage and generate a [Cobertura, Clover or JaCoCo] XML report.
-   For example, if you are using `nosetests`__ and `coverage.py`__:
+   For example, using `pytest-cov`__:
 
 .. code:: bash
 
-    nosetests --with-coverage
-    coverage xml
+    pytest --cov --cov-report=xml
 
-__ http://nose.readthedocs.org
-__ http://nedbatchelder.com/code/coverage/
+__ https://pypi.org/project/pytest-cov
 
 This will create a ``coverage.xml`` file in the current working directory.
 

--- a/diff_cover/tests/helpers.py
+++ b/diff_cover/tests/helpers.py
@@ -7,7 +7,6 @@ import io
 import six
 import os.path
 import difflib
-from nose.tools import ok_
 
 HUNK_BUFFER = 2
 MAX_LINE_LENGTH = 300
@@ -41,7 +40,7 @@ def assert_long_str_equal(expected, actual, strip=False):
         )
 
         # Fail the test
-        ok_(False, '\n\n' + '\n'.join(diff))
+        assert False, '\n\n' + '\n'.join(diff)
 
 
 def fixture_path(rel_path):

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,7 +1,6 @@
 # Common requirements for developing on all supported python versions
 mock
-nose
-coverage
+pytest-cov
 pycodestyle>=2.4.0
 flake8
 pyflakes

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ whitelist_externals =
 deps =
     -r{toxinidir}/requirements/test-requirements.txt
 commands =
-    coverage run -m nose {posargs}
-    coverage xml
+    python -m pytest --cov --cov-report=xml {posargs}
     git fetch origin master:refs/remotes/origin/master
     diff-cover coverage.xml
     diff-quality --violation=pycodestyle


### PR DESCRIPTION
Nose has been deprecated for awhile now, according to their website (https://nose.readthedocs.io/en/latest/):

    Nose has been in maintenance mode for the past several years and
    will likely cease without a new person/team to take over maintainership.

pytest on the other hand is under very active development